### PR TITLE
Add L2P paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ This section contains the prompt learning methods designed for various NLP task.
 
 22. **Learning to Prompt for Continual Learning.** CVPR 2022. ![](https://img.shields.io/badge/L2P-blue) ![](https://img.shields.io/badge/Continual_Learning-brown) ![](https://img.shields.io/badge/Prompt_Pool-red)
 
-      *Zifeng Wang, Zizhao Zhang, Chen-Yu Lee, Han Zhang, Ruoxi Sun, Xiaoqi Ren, Guolong Su, Vincent Perot, Jennifer Dy, Tomas Pfister.* [[pdf](https://arxiv.org/abs/2112.08654)], 2021.12
+      *Zifeng Wang, Zizhao Zhang, Chen-Yu Lee, Han Zhang, Ruoxi Sun, Xiaoqi Ren, Guolong Su, Vincent Perot, Jennifer Dy, Tomas Pfister.* [[pdf](https://arxiv.org/abs/2112.08654)], [[project](https://github.com/google-research/l2p)], 2021.12
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,11 @@ This section contains the prompt learning methods designed for various NLP task.
 
       *Hongbin Ye, Ningyu Zhang, Shumin Deng, Xiang Chen, Hui Chen, Feiyu Xiong, Xi Chen, Huajun Chen.* [[pdf](https://arxiv.org/abs/2201.11332)], 2022.1
 
+
+22. **Learning to Prompt for Continual Learning.** CVPR 2022. ![](https://img.shields.io/badge/L2P-blue) ![](https://img.shields.io/badge/Continual_Learning-brown) ![](https://img.shields.io/badge/Prompt_Pool-red)
+
+      *Zifeng Wang, Zizhao Zhang, Chen-Yu Lee, Han Zhang, Ruoxi Sun, Xiaoqi Ren, Guolong Su, Vincent Perot, Jennifer Dy, Tomas Pfister.* [[pdf](https://arxiv.org/abs/2112.08654)], 2021.12
+
 ## Contribution
 
 ### Other contributors 


### PR DESCRIPTION
Hi,

I added our CVPR2022 paper: Learning to Prompt for Continual Learning (L2P). Although it is not specifically applied on NLP tasks (it has the potential though), we think this paper is highly related to the topic of prompt and would like to recommend it here:) Thank you so much!

Best,
Zifeng